### PR TITLE
New rule StylesAttributesShouldHaveValue

### DIFF
--- a/src/HtmlCleanser.Tests/HtmlCleanserTests.cs
+++ b/src/HtmlCleanser.Tests/HtmlCleanserTests.cs
@@ -63,6 +63,14 @@ namespace HtmlCleanser.Tests
             Assert.True(cleansed.Contains("MY MESSAGE"));//just assert pretty much that there were no exceptions
         }
 
+        [Test]
+        public void CleanseFullStylesAttributesShouldHaveValue()
+        {
+            const string html = "<html><body><div name=\"divtagdefaultwrapper\" style=\"font-family:Calibri,Arial,Helvetica,sans-serif; font-size:; margin: 0\"></div></body></html>";
+            var cleansed = new HtmlCleanser(new Rules.StylesAttributesShouldHaveValue()).CleanseFull(html, true);
+            Assert.AreEqual("<div name=\"divtagdefaultwrapper\" style=\"font-family: calibri,arial,helvetica,sans-serif;margin: 0;\"></div>", cleansed);
+        }
+
         #endregion
 
         #region MoveCssInline

--- a/src/HtmlCleanser/HtmlCleanser.cs
+++ b/src/HtmlCleanser/HtmlCleanser.cs
@@ -30,6 +30,7 @@ namespace HtmlCleanser
                     new DocumentShouldNotReferenceResources(),
                     new TextNodesShouldBeEscaped(),
                     new BaseTagShouldNotHaveHref(),
+                    new StylesAttributesShouldHaveValue()
                 };
             _rules.AddRange(extraRules);
         }

--- a/src/HtmlCleanser/HtmlCleanser.csproj
+++ b/src/HtmlCleanser/HtmlCleanser.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Rules\BaseTagShouldNotHaveHref.cs" />
     <Compile Include="Rules\ConditionalCommentsShouldBeIgnored.cs" />
     <Compile Include="Rules\DocumentShouldNotReferenceResources.cs" />
+    <Compile Include="Rules\StylesAttributesShouldHaveValue.cs" />
     <Compile Include="Rules\StylesShouldBeInline.cs" />
     <Compile Include="Rules\TextNodesShouldBeEscaped.cs" />
     <Compile Include="StyleClass.cs" />

--- a/src/HtmlCleanser/Rules/StylesAttributesShouldHaveValue.cs
+++ b/src/HtmlCleanser/Rules/StylesAttributesShouldHaveValue.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using HtmlAgilityPack;
+
+namespace HtmlCleanser.Rules
+{
+    /// <summary>
+    /// Remove all styles attributtes that don`t have a value. For ex. style="font-family:Calibri,Arial,Helvetica,sans-serif; font-size:; margin: 0"
+    /// => style="font-family:Calibri,Arial,Helvetica,sans-serif;margin: 0"
+    /// </summary>
+    public class StylesAttributesShouldHaveValue : IHtmlCleanserRule
+    {
+        public void Perform(HtmlDocument doc)
+        {
+            var nodes = doc.DocumentNode.Descendants();
+            if (nodes == null) return;
+            var cssParser = GetCssParser();
+            foreach (var n in nodes)
+            {
+                var styleAttribute = n.Attributes["style"];
+                if (styleAttribute != null)
+                {
+                    var parsedStyles = new StyleClass(cssParser.ParseStyleClass("styleTag", styleAttribute.Value));
+                    var parsedStyleToDelete = new Dictionary<string, string>();
+                    foreach (var a in parsedStyles.Attributes)
+                    {
+                        if (string.IsNullOrWhiteSpace(a.Value))
+                            parsedStyleToDelete.Add(a.Key, a.Value);
+                    }
+                    if (parsedStyleToDelete.Count > 0)
+                    {
+                        foreach (var s in parsedStyleToDelete)
+                            parsedStyles.Attributes.Remove(s.Key);
+                        styleAttribute.Value = parsedStyles.ToString();
+                    }
+                }
+            }
+        }
+
+        protected virtual CssParser GetCssParser()
+        {
+            return new CssParser();
+        }
+    }
+}


### PR DESCRIPTION
New rule (StylesAttributesShouldHaveValue) - Remove all styles attributtes that don`t have a value. For ex. style="font-family:Calibri,Arial,Helvetica,sans-serif; font-size:; margin: 0"  => style="font-family:Calibri,Arial,Helvetica,sans-serif;margin: 0"