### PR TITLE
Add rule: RemoveTeletypeTextTags

### DIFF
--- a/src/HtmlCleanser.Tests/HtmlCleanser.Tests.csproj
+++ b/src/HtmlCleanser.Tests/HtmlCleanser.Tests.csproj
@@ -69,6 +69,9 @@
       <Name>HtmlCleanser</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/HtmlCleanser.Tests/HtmlCleanserTests.cs
+++ b/src/HtmlCleanser.Tests/HtmlCleanserTests.cs
@@ -71,6 +71,14 @@ namespace HtmlCleanser.Tests
             Assert.AreEqual("<div name=\"divtagdefaultwrapper\" style=\"font-family: calibri,arial,helvetica,sans-serif;margin: 0;\"></div>", cleansed);
         }
 
+        [Test]
+        public void CleanseFullRemoveTeletypeTextTags()
+        {
+            const string html = @"<html><body><p><tt>test</tt></p></body></html>";
+            var cleansed = new HtmlCleanser(new Rules.RemoveTeletypeTextTags()).CleanseFull(html, true);
+            Assert.AreEqual("<p>test</p>", cleansed);
+        }
+
         #endregion
 
         #region MoveCssInline

--- a/src/HtmlCleanser/HtmlCleanser.csproj
+++ b/src/HtmlCleanser/HtmlCleanser.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Rules\BaseTagShouldNotHaveHref.cs" />
     <Compile Include="Rules\ConditionalCommentsShouldBeIgnored.cs" />
     <Compile Include="Rules\DocumentShouldNotReferenceResources.cs" />
+    <Compile Include="Rules\RemoveTeletypeTextTags.cs" />
     <Compile Include="Rules\StylesAttributesShouldHaveValue.cs" />
     <Compile Include="Rules\StylesShouldBeInline.cs" />
     <Compile Include="Rules\TextNodesShouldBeEscaped.cs" />

--- a/src/HtmlCleanser/Rules/RemoveTeletypeTextTags.cs
+++ b/src/HtmlCleanser/Rules/RemoveTeletypeTextTags.cs
@@ -1,0 +1,21 @@
+﻿using HtmlAgilityPack;
+
+namespace HtmlCleanser.Rules
+{
+    public class RemoveTeletypeTextTags : IHtmlCleanserRule
+    {
+        public void Perform(HtmlDocument doc)
+        {
+            var nodes = doc.DocumentNode.SelectNodes("//tt");
+            if (nodes == null) return;
+            foreach (var node in nodes)
+            {
+                foreach (HtmlNode child in node.ChildNodes)
+                {
+                    node.ParentNode.InsertBefore(child, node);
+                    node.Remove();
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The <tt> tag is not supported in HTML5.

Telerik Silverlight HtmlDataProvider don't recognize it and don't show text at all.