### PR TITLE
Ignore SQLite Folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,5 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+
+src/\.vs/HtmlCleanser/v15/sqlite3/


### PR DESCRIPTION
When building the solution, a .ide files will be generated in src/vs/HtmlCleanser/v15/sqlite3/ which can cause contributors to accidentally commit temp files into the repository.

I've added the whole sqlite3 folder to .gitignore to prevent this kind of accidents.