### PR TITLE
Update Nuget packages

### DIFF
--- a/src/HtmlCleanser.Tests/HtmlCleanser.Tests.csproj
+++ b/src/HtmlCleanser.Tests/HtmlCleanser.Tests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="NUnit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/HtmlCleanser/HtmlCleanser.csproj
+++ b/src/HtmlCleanser/HtmlCleanser.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.5' OR '$(TargetFramework)'=='netstandard1.6' OR '$(TargetFramework)'=='netstandard2.0'">
-    <PackageReference Include="HtmlAgilityPack.CssSelectors.NetCore" Version="1.0.0" />
+    <PackageReference Include="HtmlAgilityPack.CssSelectors.NetCore" Version="1.1.0" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.5' OR '$(TargetFramework)'=='netstandard1.6' OR '$(TargetFramework)'=='netstandard2.0'">


### PR DESCRIPTION
Update Nuget packages to latest version.

**Current Issue:** 
Test failed in `CleanseFullShouldEscapeCrappyChars` in which the `CleanseFull` method unexpectedly returned a `&lt;`.

Result: `<html><body>asd<div>&lt;</div>&amp;</body></html>`
Expected: `<html><body>asd<div></div>&amp;</body></html>`

Should we escape this character or not? What's your input? @lukeschafer 